### PR TITLE
Matches sourcelinekey XML position to match docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@johnathanalves/intacct-sdk",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Sage Intacct SDK for JavaScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Functions/Purchasing/AbstractPurchasingTransactionLine.ts
+++ b/src/Functions/Purchasing/AbstractPurchasingTransactionLine.ts
@@ -21,9 +21,7 @@ import IaXmlWriter from "../../Xml/IaXmlWriter";
 import IXmlObject from "../../Xml/IXmlObject";
 import AbstractTransactionItemDetail from "../InventoryControl/AbstractTransactionItemDetail";
 
-export default abstract class AbstractPurchasingTransactionLine
-    implements IXmlObject
-{
+export default abstract class AbstractPurchasingTransactionLine implements IXmlObject {
     public itemId: string;
     public itemDescription: string;
     public taxable: boolean;
@@ -31,6 +29,7 @@ export default abstract class AbstractPurchasingTransactionLine
     public quantity: number;
     public unit: string;
     public price: number;
+    public sourceLineKey: string;
     public overrideTaxAmount: number;
     public tax: number;
     public memo: string;
@@ -49,7 +48,6 @@ export default abstract class AbstractPurchasingTransactionLine
     public costTypeId: string;
     public taskId: string;
     public needByDate: Date;
-    public sourceLineKey: string;
 
     public abstract writeXml(xml: IaXmlWriter): void;
 }

--- a/src/Functions/Purchasing/PurchasingTransactionLineCreate.ts
+++ b/src/Functions/Purchasing/PurchasingTransactionLineCreate.ts
@@ -21,49 +21,51 @@ import IaXmlWriter from "../../Xml/IaXmlWriter";
 import AbstractPurchasingTransactionLine from "./AbstractPurchasingTransactionLine";
 
 export default class PurchasingTransactionLineCreate extends AbstractPurchasingTransactionLine {
-  public writeXml(xml: IaXmlWriter): void {
-    xml.writeStartElement("potransitem");
+    public writeXml(xml: IaXmlWriter): void {
+        xml.writeStartElement("potransitem");
 
-    xml.writeElement("itemid", this.itemId, true);
-    xml.writeElement("itemdesc", this.itemDescription);
-    xml.writeElement("taxable", this.taxable);
-    xml.writeElement("warehouseid", this.warehouseId);
-    xml.writeElement("quantity", this.quantity, true);
-    xml.writeElement("unit", this.unit);
-    xml.writeElement("price", this.price);
-    xml.writeElement("overridetaxamount", this.overrideTaxAmount);
-    xml.writeElement("tax", this.tax);
-    xml.writeElement("locationid", this.locationId);
-    xml.writeElement("departmentid", this.departmentId);
-    xml.writeElement("memo", this.memo);
+        xml.writeElement("itemid", this.itemId, true);
+        xml.writeElement("itemdesc", this.itemDescription);
+        xml.writeElement("taxable", this.taxable);
+        xml.writeElement("warehouseid", this.warehouseId);
+        xml.writeElement("quantity", this.quantity, true);
+        xml.writeElement("unit", this.unit);
+        xml.writeElement("price", this.price);
+        if (this.sourceLineKey != null) {
+            xml.writeElement("sourcelinekey", this.sourceLineKey);
+        }
+        xml.writeElement("overridetaxamount", this.overrideTaxAmount);
+        xml.writeElement("tax", this.tax);
+        xml.writeElement("locationid", this.locationId);
+        xml.writeElement("departmentid", this.departmentId);
+        xml.writeElement("memo", this.memo);
 
-    if (this.itemDetails != null && this.itemDetails.length > 0) {
-      xml.writeStartElement("itemdetails");
-      for (const itemDetail of this.itemDetails) {
-        itemDetail.writeXml(xml);
-      }
-      xml.writeEndElement(); // itemdetails
+        if (this.itemDetails != null && this.itemDetails.length > 0) {
+            xml.writeStartElement("itemdetails");
+            for (const itemDetail of this.itemDetails) {
+                itemDetail.writeXml(xml);
+            }
+            xml.writeEndElement(); // itemdetails
+        }
+
+        xml.writeElement("form1099", this.form1099);
+
+        xml.writeCustomFieldsExplicit(this.customFields);
+
+        xml.writeElement("projectid", this.projectId);
+        xml.writeElement("taskid", this.taskId);
+        xml.writeElement("costtypeid", this.costTypeId);
+        xml.writeElement("customerid", this.customerId);
+        xml.writeElement("vendorid", this.vendorId);
+        xml.writeElement("employeeid", this.employeeId);
+        xml.writeElement("classid", this.classId);
+        xml.writeElement("contractid", this.contractId);
+        xml.writeElement("billable", this.billable);
+
+        xml.writeStartElement("needbydate");
+        xml.writeDateSplitElements(this.needByDate, true);
+        xml.writeEndElement(); // needbydate
+
+        xml.writeEndElement(); // potransitem
     }
-
-    xml.writeElement("form1099", this.form1099);
-
-    xml.writeCustomFieldsExplicit(this.customFields);
-
-    xml.writeElement("sourcelinekey", this.sourceLineKey);
-    xml.writeElement("projectid", this.projectId);
-    xml.writeElement("taskid", this.taskId);
-    xml.writeElement("costtypeid", this.costTypeId);
-    xml.writeElement("customerid", this.customerId);
-    xml.writeElement("vendorid", this.vendorId);
-    xml.writeElement("employeeid", this.employeeId);
-    xml.writeElement("classid", this.classId);
-    xml.writeElement("contractid", this.contractId);
-    xml.writeElement("billable", this.billable);
-
-    xml.writeStartElement("needbydate");
-    xml.writeDateSplitElements(this.needByDate, true);
-    xml.writeEndElement(); // needbydate
-
-    xml.writeEndElement(); // potransitem
-  }
 }

--- a/src/Functions/Purchasing/PurchasingTransactionLineUpdate.ts
+++ b/src/Functions/Purchasing/PurchasingTransactionLineUpdate.ts
@@ -34,6 +34,9 @@ export default class PurchasingTransactionLineUpdate extends AbstractPurchasingT
         xml.writeElement("quantity", this.quantity);
         xml.writeElement("unit", this.unit);
         xml.writeElement("price", this.price);
+        if (this.sourceLineKey != null) {
+            xml.writeElement("sourcelinekey", this.sourceLineKey);
+        }
         xml.writeElement("locationid", this.locationId);
         xml.writeElement("departmentid", this.departmentId);
         xml.writeElement("memo", this.memo);
@@ -50,7 +53,6 @@ export default class PurchasingTransactionLineUpdate extends AbstractPurchasingT
 
         xml.writeCustomFieldsExplicit(this.customFields);
 
-        xml.writeElement("sourcelinekey", this.sourceLineKey);
         xml.writeElement("projectid", this.projectId);
         xml.writeElement("taskid", this.taskId);
         xml.writeElement("costtypeid", this.costTypeId);

--- a/src/Functions/Purchasing/PurchasingTransactionLineUpdate.ts
+++ b/src/Functions/Purchasing/PurchasingTransactionLineUpdate.ts
@@ -63,6 +63,12 @@ export default class PurchasingTransactionLineUpdate extends AbstractPurchasingT
         xml.writeElement("contractid", this.contractId);
         xml.writeElement("billable", this.billable);
 
+        if (this.needByDate != null) {
+            xml.writeStartElement("needbydate");
+            xml.writeDateSplitElements(this.needByDate, true);
+            xml.writeEndElement(); // needbydate
+        }
+
         xml.writeEndElement(); // updatepotransitem
     }
 }

--- a/test/Functions/Purchasing/PurchasingTransactionCreateTest.ts
+++ b/test/Functions/Purchasing/PurchasingTransactionCreateTest.ts
@@ -58,6 +58,11 @@ describe("PurchasingTransactionCreate", () => {
                 <potransitem>
                     <itemid>02354032</itemid>
                     <quantity>1200</quantity>
+                    <needbydate>
+                        <year>2015</year>
+                        <month>06</month>
+                        <day>30</day>
+                    </needbydate>
                 </potransitem>
             </potransitems>
         </create_potransaction>
@@ -74,6 +79,7 @@ describe("PurchasingTransactionCreate", () => {
         const line1 = new PurchasingTransactionLineCreate();
         line1.itemId = "02354032";
         line1.quantity = 1200;
+        line1.needByDate = new Date("6/30/2015");
 
         record.lines = [
             line1,
@@ -136,6 +142,11 @@ describe("PurchasingTransactionCreate", () => {
                 <potransitem>
                     <itemid>2390552</itemid>
                     <quantity>223</quantity>
+                    <needbydate>
+                        <year>2015</year>
+                        <month>06</month>
+                        <day>30</day>
+                    </needbydate>
                 </potransitem>
             </potransitems>
             <subtotals>
@@ -177,6 +188,7 @@ describe("PurchasingTransactionCreate", () => {
         const line1 = new PurchasingTransactionLineCreate();
         line1.itemId = "2390552";
         line1.quantity = 223;
+        line1.needByDate = new Date("6/30/2015");
 
         record.lines = [
             line1,

--- a/test/Functions/Purchasing/PurchasingTransactionLineCreateTest.ts
+++ b/test/Functions/Purchasing/PurchasingTransactionLineCreateTest.ts
@@ -36,12 +36,18 @@ describe("PurchasingTransactionLineCreate", () => {
     <potransitem>
         <itemid>26323</itemid>
         <quantity>2340</quantity>
+        <needbydate>
+            <year>2015</year>
+            <month>06</month>
+            <day>30</day>
+        </needbydate>
     </potransitem>
 </test>`;
 
         const record = new PurchasingTransactionLineCreate();
         record.itemId = "26323";
         record.quantity = 2340;
+        record.needByDate = new Date("6/30/2015");
 
         XmlObjectTestHelper.CompareXml(expected, record);
     });
@@ -81,6 +87,11 @@ describe("PurchasingTransactionLineCreate", () => {
         <classid>243609</classid>
         <contractid>9062</contractid>
         <billable>true</billable>
+        <needbydate>
+            <year>2015</year>
+            <month>06</month>
+            <day>30</day>
+        </needbydate>
     </potransitem>
 </test>`;
 
@@ -108,6 +119,7 @@ describe("PurchasingTransactionLineCreate", () => {
         record.customFields = [
             [ "customfield1", "customvalue1" ],
         ];
+        record.needByDate = new Date("6/30/2015");
 
         const detail1 = new TransactionItemDetail();
         detail1.quantity = 52;

--- a/test/Functions/Purchasing/PurchasingTransactionLineUpdateTest.ts
+++ b/test/Functions/Purchasing/PurchasingTransactionLineUpdateTest.ts
@@ -75,6 +75,11 @@ describe("PurchasingTransactionLineUpdate", () => {
         <classid>243609</classid>
         <contractid>9062</contractid>
         <billable>true</billable>
+        <needbydate>
+            <year>2015</year>
+            <month>06</month>
+            <day>30</day>
+        </needbydate>
     </updatepotransitem>
 </test>`;
 
@@ -101,6 +106,7 @@ describe("PurchasingTransactionLineUpdate", () => {
         record.customFields = [
             [ "customfield1", "customvalue1" ],
         ];
+        record.needByDate = new Date("6/30/2015");
 
         const detail1 = new TransactionItemDetail();
         detail1.quantity = 52;

--- a/test/Functions/Purchasing/PurchasingTransactionUpdateTest.ts
+++ b/test/Functions/Purchasing/PurchasingTransactionUpdateTest.ts
@@ -97,10 +97,20 @@ describe("PurchasingTransactionUpdate", () => {
                 <updatepotransitem line_num="1">
                     <itemid>02354032</itemid>
                     <quantity>223</quantity>
+                    <needbydate>
+                        <year>2015</year>
+                        <month>06</month>
+                        <day>30</day>
+                    </needbydate>
                 </updatepotransitem>
                 <potransitem>
                     <itemid>2390552</itemid>
                     <quantity>223</quantity>
+                    <needbydate>
+                        <year>2016</year>
+                        <month>06</month>
+                        <day>30</day>
+                    </needbydate>
                 </potransitem>
             </updatepotransitems>
             <updatesubtotals>
@@ -140,10 +150,12 @@ describe("PurchasingTransactionUpdate", () => {
         line1.lineNo = 1;
         line1.itemId = "02354032";
         line1.quantity = 223;
+        line1.needByDate = new Date("6/30/2015");
 
         const line2 = new PurchasingTransactionLineCreate();
         line2.itemId = "2390552";
         line2.quantity = 223;
+        line2.needByDate = new Date("6/30/2016");
 
         record.lines = [
             line1,


### PR DESCRIPTION
I'm not sure these changes are necessary. But the last PR was causing PO syncs to throw `this.xml.hasOwnProperty is not a function` errors.  Likely from `src/Xml/AbstractResponse.ts` line 48. 

I haven't been able to pinpoint the problem.  However, John pointed out that the order of the arguments in the XML payload I built didn't match the docs, so this PR moves `sourcelinekey` to its proper position. 

The PR also conditionally only includes the field in the payload when the field is present.  The field is only needed when creating a Bill/invoice that has a reference to a PO. It was failing when trying to create POs, so I'm omitting it in case that is what was causing the problem. Very scientific.

I also fixed tests and tried to revert some auto-formatting stuff that I committed in previously that went against the patterns in the rest of the repo. 